### PR TITLE
Fix .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,13 +2,10 @@ image:
   file: Dockerfile
 
 tasks:
-  - command : dotnet run
-  
-tasks:
-  - command : dotnet restore
-  
-tasks:
-  - command : dotnet build
+  - command: >
+      dotnet run &&
+      dotnet restore &&
+      dotnet build
   
 ports:
   - port: 5000


### PR DESCRIPTION
I noticed that the `.gitpod.yml` configuration was not picked up when I opened this repository in Gitpod.

Investigating further, in the browser console, I found this error message:

> Unparsable Gitpod configuration
> name: "YAMLException"
> reason: "duplicated mapping key"

The reason is that there should be only one `tasks:` entry (but it can have multiple Terminals as children, and each Terminal can have instructions and phases).